### PR TITLE
Promises instead callbacks. Now server not crashed if send bad token.

### DIFF
--- a/JavaScript/session.js
+++ b/JavaScript/session.js
@@ -40,14 +40,13 @@ class Session extends Map {
     const { cookie } = client;
     if (!cookie) return;
     const sessionToken = cookie.token;
-    if (sessionToken) {
-      const session = await storage.get(sessionToken);
-      if (!session) return;
-      Object.setPrototypeOf(session, Session.prototype);
-      client.token = sessionToken;
-      client.session = session;
-      return session;
-    }
+    if (!sessionToken) return;
+    const session = await storage.get(sessionToken);
+    if (!session) return;
+    Object.setPrototypeOf(session, Session.prototype);
+    client.token = sessionToken;
+    client.session = session;
+    return session;
   }
 
   static delete(client) {

--- a/JavaScript/session.js
+++ b/JavaScript/session.js
@@ -36,20 +36,17 @@ class Session extends Map {
     return session;
   }
 
-  static restore(client) {
+  static async restore(client) {
     const { cookie } = client;
     if (!cookie) return;
     const sessionToken = cookie.token;
     if (sessionToken) {
-      return new Promise((resolve, reject) => {
-        storage.get(sessionToken, (err, session) => {
-          if (err) reject(new Error('No session'));
-          Object.setPrototypeOf(session, Session.prototype);
-          client.token = sessionToken;
-          client.session = session;
-          resolve(session);
-        });
-      });
+      const session = await storage.get(sessionToken);
+      if (!session) return;
+      Object.setPrototypeOf(session, Session.prototype);
+      client.token = sessionToken;
+      client.session = session;
+      return session;
     }
   }
 

--- a/JavaScript/storage.js
+++ b/JavaScript/storage.js
@@ -1,23 +1,16 @@
 'use strict';
 
-const fs = require('node:fs');
+const fs = require('node:fs').promises;
 const path = require('node:path');
 const v8 = require('node:v8');
 
 const PATH = `${__dirname}/sessions`;
 
-const safePath = (fn) => (token, ...args) => {
-  const callback = args[args.length - 1];
-  if (typeof token !== 'string') {
-    callback(new Error('Invalid session token'));
-    return;
-  }
+const safePath = (promise) => (token, ...args) => {
+  if (typeof token !== 'string') throw new Error('Invalid session token');
   const fileName = path.join(PATH, token);
-  if (!fileName.startsWith(PATH)) {
-    callback(new Error('Invalid session token'));
-    return;
-  }
-  fn(fileName, ...args);
+  if (!fileName.startsWith(PATH)) throw new Error('Invalid session token');
+  return promise(fileName, ...args)
 };
 
 const readSession = safePath(fs.readFile);
@@ -25,39 +18,34 @@ const writeSession = safePath(fs.writeFile);
 const deleteSession = safePath(fs.unlink);
 
 class Storage extends Map {
-  get(key, callback) {
+  async get(key) {
     const value = super.get(key);
-    if (value) {
-      callback(null, value);
-      return;
+    if (value) return value;
+    let data;
+    try {
+      data = await readSession(key);
+    } catch (err) {
+      return undefined;
     }
-    readSession(key, (err, data) => {
-      if (err) {
-        callback(err);
-        return;
-      }
-      console.log(`Session loaded: ${key}`);
-      const session = v8.deserialize(data);
-      super.set(key, session);
-      callback(null, session);
-    });
+    console.log('Session loaded: ${key}');
+    const session = v8.deserialize(data);
+    super.set(key, session);
+    return session;
   }
 
-  save(key) {
+  async save(key) {
     const value = super.get(key);
     if (value) {
       const data = v8.serialize(value);
-      writeSession(key, data, () => {
-        console.log(`Session saved: ${key}`);
-      });
+      await writeSession(key, data);
+      console.log(`Session saved: ${key}`);
     }
   }
 
-  delete(key) {
+  async delete(key) {
     console.log('Delete: ', key);
-    deleteSession(key, () => {
-      console.log(`Session deleted: ${key}`);
-    });
+    await deleteSession(key);
+    console.log(`Session deleted: ${key}`);
   }
 }
 


### PR DESCRIPTION
1. All callback into `storage.js` to promise (async/await).
1.1. Now function `safePath` takes a promise as the first argument and return promise, instead callback contract.
`const safePath = (fn) => (token, ...args) => {`
`const safePath = (promise) => (token, ...args) => {`
1.2. All methods in Storage async. This method await safePath promises.
`async get(key) {`
`data = await readSession(key);`
`async save(key) {`
`await writeSession(key, data);`
`async delete(key) {`
`await deleteSession(key);`
2. Storage return `undefined` if not found file session.
```
try {
  data = await readSession(key);
} catch (err) {
  return undefined;
}
```
This makes Storage contract look more like Map contract(if not found return `undefined`).
3. Session.restore method
```
static restore(client) {
  const { cookie } = client;
  if (!cookie) return;
  const sessionToken = cookie.token;
  if (sessionToken) {
    return new Promise((resolve, reject) => {
      storage.get(sessionToken, (err, session) => {
        if (err) reject(new Error('No session'));
        Object.setPrototypeOf(session, Session.prototype);
        client.token = sessionToken;
        client.session = session;
        resolve(session);
      });
    });
  }
}
```
```
static async restore(client) {
  const { cookie } = client;
  if (!cookie) return;
  const sessionToken = cookie.token;
  if (!sessionToken) return;
  const session = await storage.get(sessionToken);
  if (!session) return;
  Object.setPrototypeOf(session, Session.prototype);
  client.token = sessionToken;
  client.session = session;
  return session;
}
```
Now if you pass a bad token, the server will not crash.