### PR TITLE
New server not crashed if send bad token

### DIFF
--- a/JavaScript/client.js
+++ b/JavaScript/client.js
@@ -27,7 +27,11 @@ class Client {
 
   static async getInstance(req, res) {
     const client = new Client(req, res);
-    await Session.restore(client);
+    try {
+      await Session.restore(client);
+    } catch {
+      throw new Error("Couldn't restore session");
+    }
     return client;
   }
 

--- a/JavaScript/server.js
+++ b/JavaScript/server.js
@@ -5,6 +5,8 @@ const http = require('node:http');
 const Client = require('./client.js');
 const Session = require('./session.js');
 
+const INVALID_TOKEN_CODE = 498;
+
 const routing = {
   '/': async () => '<h1>welcome to homepage</h1><hr>',
   '/start': async (client) => {
@@ -46,7 +48,13 @@ const types = {
 };
 
 http.createServer(async (req, res) => {
-  const client = await Client.getInstance(req, res);
+  try {
+    const client = await Client.getInstance(req, res);
+  } catch {
+    res.statusCode = INVALID_TOKEN_CODE;
+    res.end();
+    return;
+  }
   const { method, url, headers } = req;
   console.log(`${method} ${url} ${headers.cookie}`);
   const handler = routing[url];

--- a/JavaScript/session.js
+++ b/JavaScript/session.js
@@ -43,7 +43,10 @@ class Session extends Map {
     if (sessionToken) {
       return new Promise((resolve, reject) => {
         storage.get(sessionToken, (err, session) => {
-          if (err) reject(new Error('No session'));
+          if (err) {
+            reject(new Error('No session'));
+            return;
+          }
           Object.setPrototypeOf(session, Session.prototype);
           client.token = sessionToken;
           client.session = session;


### PR DESCRIPTION
Now if you sand token that not contained on Storage, server not crashed.

There are several points of contention.
1. If Storage did not find a session by key. Pass error to callback or pass undefined?
> Now. (pass error)
> ```
> if (err) {
>   callback(err);
>   return;
> }
> ```
> Maybe return undefined more correct? It's make `Storage` more like look on `Map`.
> ```
> if (err) {
>   callback(null, undefined);
>   return;
> }
> ```
2. Maybe should drop "getIntsance". Because this method, it only creates a client with a session.  

> If it was not possible to create a client, then it cannot be passed to the handler, then you need to respond with an empty page.
> Now
> ```
> try {
>   const client = await Client.getInstance(req, res);
> } catch {
>   res.statusCode = INVALID_TOKEN_CODE;
>   res.end();
>   return;
> }
> ```
> More correct?
> ```
> const client = new Client(req, res);
> try {
>   await Session.restore(client)
> } catch {
>   ???????
> }
> ```